### PR TITLE
Updates for NumPy 2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -164,41 +164,41 @@ jobs:
       matrix:
         py: ["38", "39", "310", "311", "312"]
         arch: ["x86_64"] #, "i686"]
-        libc: ["many"] #, "musl"]
-        # include:
-        #   - py: "312"
-        #     arch: "aarch64"
-        #     libc: "many"
+        libc: ["many", "musl"]
+        include:
+          - py: "312"
+            arch: "aarch64"
+            libc: "many"
         #   - py: "312"
         #     arch: "ppc64le"
         #     libc: "many"
         #   - py: "312"
         #     arch: "s390x"
         #     libc: "many"
-        #   - py: "311"
-        #     arch: "aarch64"
-        #     libc: "many"
+          - py: "311"
+            arch: "aarch64"
+            libc: "many"
         #   - py: "311"
         #     arch: "ppc64le"
         #     libc: "many"
         #   - py: "311"
         #     arch: "s390x"
         #     libc: "many"
-        #   - py: "310"
-        #     arch: "aarch64"
-        #     libc: "many"
+          - py: "310"
+            arch: "aarch64"
+            libc: "many"
         #   - py: "310"
         #     arch: "ppc64le"
         #     libc: "many"
         #   - py: "310"
         #     arch: "s390x"
         #     libc: "many"
-        #   - py: "39"
-        #     arch: "aarch64"
-        #     libc: "many"
-        #   - py: "38"
-        #     arch: "aarch64"
-        #     libc: "many"
+          - py: "39"
+            arch: "aarch64"
+            libc: "many"
+          - py: "38"
+            arch: "aarch64"
+            libc: "many"
       fail-fast: false
     env:
       BOOST_INCLUDE: include
@@ -308,22 +308,22 @@ jobs:
 
   macos-wheel:
     name: Build ${{ matrix.macos-version }} Wheels for py${{ matrix.py }}
-    runs-on: macos-14
+    runs-on: ${{ matrix.macos-version }}
     needs: ["sdist", "post-pending-status"]
     outputs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        macos-version: [ "macos-14" ]
+        macos-version: [ "macos-13", "macos-14" ]
         py: [ "39", "310", "311", "312" ]
-        deployment_target: ["11.0"]
+        deployment_target: [ "11.0" ]
         include:
-          # - py: "38"
-          #   deployment_target: "10.15"
-          #   macos-version: "macos-13"
           - py: "38"
             deployment_target: "10.15"
-            macos-oversion: "macos-14"
+            macos-version: "macos-13"
+          - py: "38"
+            deployment_target: "10.15"
+            macos-version: "macos-14"
       fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -308,19 +308,19 @@ jobs:
 
   macos-wheel:
     name: Build ${{ matrix.macos-version }} Wheels for py${{ matrix.py }}
-    runs-on: ${{ matrix.macos-version }}
+    runs-on: macos-14
     needs: ["sdist", "post-pending-status"]
     outputs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        macos-version: [ "macos-13", "macos-14" ]
+        macos-version: [ "macos-14" ]
         py: [ "39", "310", "311", "312" ]
         deployment_target: ["11.0"]
         include:
-          - py: "38"
-            deployment_target: "10.15"
-            macos-version: "macos-13"
+          # - py: "38"
+          #   deployment_target: "10.15"
+          #   macos-version: "macos-13"
           - py: "38"
             deployment_target: "10.15"
             macos-oversion: "macos-14"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./build/python_sdist/dist/*.tar.gz
-          name: sdist
+          name: cibw-sdist
           if-no-files-found: error
       # Copied from https://github.com/hynek/build-and-inspect-python-package/
       - name: Show SDist contents hierarchically, including metadata.
@@ -173,7 +173,7 @@ jobs:
       - name: Download pre-built sdist
         uses: actions/download-artifact@v4
         with:
-          name: sdist
+          name: cibw-sdist
       - name: Extract the sdist tarball
         run: tar -xvf *.tar.gz --strip-components=1
       - name: Restore Boost cache
@@ -237,7 +237,7 @@ jobs:
       - name: Download pre-built sdist
         uses: actions/download-artifact@v4
         with:
-          name: sdist
+          name: cibw-sdist
       - name: Extract the sdist tarball
         run: tar -xvf *.tar.gz --strip-components=1
         shell: bash
@@ -294,7 +294,7 @@ jobs:
       - name: Download pre-built sdist
         uses: actions/download-artifact@v4
         with:
-          name: sdist
+          name: cibw-sdist
       - name: Extract the sdist tarball
         run: tar -xvf *.tar.gz --strip-components=1
       - name: Install Brew dependencies
@@ -324,22 +324,18 @@ jobs:
       - "windows-wheel"
       - "macos-wheel"
     if: github.event.inputs.upload == 'true'
+    permissions:
+      id-token: write
+    environment: pypi
     steps:
       - name: Download pre-built wheels
         uses: actions/download-artifact@v4
         with:
-          path: dist/
-          name: wheels
-      - name: Download pre-build sdist
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          name: sdist
+          path: dist
+          name: cibw-*
+          merge-multiple: true
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
   send_status_to_cantera:
     name: Send jobs status to Cantera/cantera

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -116,10 +116,10 @@ jobs:
           repository: "Cantera/cantera"
           submodules: recursive
           ref: ${{ github.event.inputs.incoming_ref }}
-      - name: Set Up Python 3.10
-        uses: actions/setup-python@v4
+      - name: Set Up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: python3 -m pip install -U pip scons build
       - name: Build the sdist
@@ -128,7 +128,7 @@ jobs:
           system_blas_lapack=n system_sundials=n system_eigen=n system_fmt=n \
           system_yamlcpp=n googletest=none
       - name: Archive the built sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./build/python_sdist/dist/*.tar.gz
           name: sdist
@@ -154,16 +154,25 @@ jobs:
 
   linux-wheel:
     name: Build ${{ matrix.libc }}linux_${{ matrix.arch }} for py${{ matrix.py }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: ["sdist", "post-pending-status"]
     outputs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        py: ["38", "39", "310", "311"]
+        py: ["38", "39", "310", "311", "312"]
         arch: ["x86_64", "i686"]
         libc: ["many", "musl"]
         include:
+          - py: "312"
+            arch: "aarch64"
+            libc: "many"
+          - py: "312"
+            arch: "ppc64le"
+            libc: "many"
+          - py: "312"
+            arch: "s390x"
+            libc: "many"
           - py: "311"
             arch: "aarch64"
             libc: "many"
@@ -194,7 +203,7 @@ jobs:
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
     steps:
       - name: Download pre-built sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
       - name: Extract the sdist tarball
@@ -219,7 +228,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_ENVIRONMENT: BOOST_INCLUDE=${{ env.BOOST_INCLUDE }} CT_SKIP_SLOW=1
           CIBW_BUILD: cp${{ matrix.py }}-${{ matrix.libc }}linux*
@@ -238,7 +247,7 @@ jobs:
           CIBW_TEST_SKIP: "*-manylinux_{i686,ppc64le,s390x} *musl*"
 
       - name: Archive the built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: wheels

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-        arch: ["x86_64", "aarch64"]
+        arch: ["x86_64"]#, "aarch64"]
         libc: ["many"]
       fail-fast: true
     env:
@@ -332,7 +332,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-          name: cibw-*
+          pattern: cibw-*
           merge-multiple: true
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -255,7 +255,7 @@ jobs:
           name: cibw-wheels-linux-${{ strategy.job-index }}
 
   windows-wheel:
-    name: Build ${{ matrix.arch }} Windows Wheels for py${{ matrix.py }}
+    name: Build Windows Wheels for py${{ matrix.py }}
     runs-on: windows-2019
     needs: ["sdist", "post-pending-status"]
     outputs:
@@ -263,7 +263,6 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-        arch: ["AMD64", "x86"]
       fail-fast: false
     env:
       BOOST_ROOT: ${{ github.workspace }}/3rdparty/boost
@@ -296,7 +295,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_ENVIRONMENT: BOOST_INCLUDE=${BOOST_ROOT} CT_SKIP_SLOW=1 CYTHON_FORCE_REGEN=${{ matrix.py == '38' && '1' || '0' }}
-          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS: "AMD64"
           CIBW_BUILD: cp${{ matrix.py }}-*
           CIBW_TEST_COMMAND: pytest -vv --durations=100 ${{ runner.temp }}/test/python
           CIBW_BEFORE_TEST: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -116,7 +116,6 @@ jobs:
           repository: "Cantera/cantera"
           submodules: recursive
           ref: ${{ github.event.inputs.incoming_ref }}
-          depth: 1
       - name: Set Up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -161,43 +161,43 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-        arch: ["x86_64", "i686"]
-        libc: ["many", "musl"]
-        include:
-          - py: "312"
-            arch: "aarch64"
-            libc: "many"
-          - py: "312"
-            arch: "ppc64le"
-            libc: "many"
-          - py: "312"
-            arch: "s390x"
-            libc: "many"
-          - py: "311"
-            arch: "aarch64"
-            libc: "many"
-          - py: "311"
-            arch: "ppc64le"
-            libc: "many"
-          - py: "311"
-            arch: "s390x"
-            libc: "many"
-          - py: "310"
-            arch: "aarch64"
-            libc: "many"
-          - py: "310"
-            arch: "ppc64le"
-            libc: "many"
-          - py: "310"
-            arch: "s390x"
-            libc: "many"
-          - py: "39"
-            arch: "aarch64"
-            libc: "many"
-          - py: "38"
-            arch: "aarch64"
-            libc: "many"
-      fail-fast: true
+        arch: ["x86_64"] #, "i686"]
+        libc: ["many"] #, "musl"]
+        # include:
+        #   - py: "312"
+        #     arch: "aarch64"
+        #     libc: "many"
+        #   - py: "312"
+        #     arch: "ppc64le"
+        #     libc: "many"
+        #   - py: "312"
+        #     arch: "s390x"
+        #     libc: "many"
+        #   - py: "311"
+        #     arch: "aarch64"
+        #     libc: "many"
+        #   - py: "311"
+        #     arch: "ppc64le"
+        #     libc: "many"
+        #   - py: "311"
+        #     arch: "s390x"
+        #     libc: "many"
+        #   - py: "310"
+        #     arch: "aarch64"
+        #     libc: "many"
+        #   - py: "310"
+        #     arch: "ppc64le"
+        #     libc: "many"
+        #   - py: "310"
+        #     arch: "s390x"
+        #     libc: "many"
+        #   - py: "39"
+        #     arch: "aarch64"
+        #     libc: "many"
+        #   - py: "38"
+        #     arch: "aarch64"
+        #     libc: "many"
+      fail-fast: false
     env:
       BOOST_INCLUDE: include
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
@@ -230,7 +230,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_ENVIRONMENT: BOOST_INCLUDE=${{ env.BOOST_INCLUDE }} CT_SKIP_SLOW=1
+          CIBW_ENVIRONMENT: BOOST_INCLUDE=${{ env.BOOST_INCLUDE }} CT_SKIP_SLOW=1 FORCE_CYTHON_COMPILE=${{ matrix.py == '38' }}
           CIBW_BUILD: cp${{ matrix.py }}-${{ matrix.libc }}linux*
           CIBW_ARCHS: ${{ matrix.arch }}
           # cibuildwheel on Linux uses a Docker container to run the build, so
@@ -268,7 +268,7 @@ jobs:
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
     steps:
       - name: Download pre-built sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
       - name: Extract the sdist tarball
@@ -291,7 +291,7 @@ jobs:
           rm $BOOST_ROOT/download.7z
         shell: bash
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_ENVIRONMENT: BOOST_INCLUDE=${BOOST_ROOT} CT_SKIP_SLOW=1
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -300,7 +300,7 @@ jobs:
           CIBW_BEFORE_TEST: |
             curl -sL "https://github.com/cantera/cantera/archive/${{ needs.post-pending-status.outputs.incoming-sha }}.tar.gz" -o ${{ runner.temp }}/cantera.tar.gz && tar -xzf ${{ runner.temp }}/cantera.tar.gz --strip-components=1 -C ${{ runner.temp }} "cantera-${{ needs.post-pending-status.outputs.incoming-sha }}/test"
       - name: Archive the built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: wheels
@@ -328,7 +328,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
     steps:
       - name: Download pre-built sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
       - name: Extract the sdist tarball
@@ -336,7 +336,7 @@ jobs:
       - name: Install Brew dependencies
         run: brew install boost
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_ENVIRONMENT: BOOST_INCLUDE="$(brew --prefix)/include" RUNNER_TEMP=${{ runner.temp }} CT_SKIP_SLOW=1
           CIBW_BUILD: cp${{ matrix.py }}-*
@@ -347,7 +347,7 @@ jobs:
           CIBW_BEFORE_TEST: |
             curl -sL "https://github.com/cantera/cantera/archive/${{ needs.post-pending-status.outputs.incoming-sha }}.tar.gz" -o ${{ runner.temp }}/cantera.tar.gz && tar -xzf ${{ runner.temp }}/cantera.tar.gz --strip-components=1 -C ${{ runner.temp }} "cantera-${{ needs.post-pending-status.outputs.incoming-sha }}/test"
       - name: Archive the built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: wheels
@@ -365,12 +365,12 @@ jobs:
     if: github.event.inputs.upload == 'true'
     steps:
       - name: Download pre-built wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist/
           name: wheels
       - name: Download pre-build sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist/
           name: sdist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -163,43 +163,9 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-        arch: ["x86_64"] #, "i686"]
-        libc: ["many", "musl"]
-        include:
-          - py: "312"
-            arch: "aarch64"
-            libc: "many"
-        #   - py: "312"
-        #     arch: "ppc64le"
-        #     libc: "many"
-        #   - py: "312"
-        #     arch: "s390x"
-        #     libc: "many"
-          - py: "311"
-            arch: "aarch64"
-            libc: "many"
-        #   - py: "311"
-        #     arch: "ppc64le"
-        #     libc: "many"
-        #   - py: "311"
-        #     arch: "s390x"
-        #     libc: "many"
-          - py: "310"
-            arch: "aarch64"
-            libc: "many"
-        #   - py: "310"
-        #     arch: "ppc64le"
-        #     libc: "many"
-        #   - py: "310"
-        #     arch: "s390x"
-        #     libc: "many"
-          - py: "39"
-            arch: "aarch64"
-            libc: "many"
-          - py: "38"
-            arch: "aarch64"
-            libc: "many"
-      fail-fast: false
+        arch: ["x86_64", "aarch64"]
+        libc: ["many"]
+      fail-fast: true
     env:
       BOOST_INCLUDE: include
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
@@ -263,7 +229,7 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-      fail-fast: false
+      fail-fast: true
     env:
       BOOST_ROOT: ${{ github.workspace }}/3rdparty/boost
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
@@ -319,12 +285,9 @@ jobs:
         deployment_target: [ "11.0" ]
         include:
           - py: "38"
-            deployment_target: "10.15"
+            deployment_target: "11.0"
             macos-version: "macos-13"
-          - py: "38"
-            deployment_target: "10.15"
-            macos-version: "macos-14"
-      fail-fast: false
+      fail-fast: true
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Extract the sdist tarball
         run: tar -xvf *.tar.gz --strip-components=1
       - name: Restore Boost cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-boost
         with:
           path: ${{ env.BOOST_INCLUDE }}/boost
@@ -224,13 +224,13 @@ jobs:
           rm $BOOST_INCLUDE/download.7z
           rm -r $BOOST_INCLUDE/boost_1_78_0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_ENVIRONMENT: BOOST_INCLUDE=${{ env.BOOST_INCLUDE }} CT_SKIP_SLOW=1 FORCE_CYTHON_COMPILE=${{ matrix.py == '38' }}
+          CIBW_ENVIRONMENT: BOOST_INCLUDE=${{ env.BOOST_INCLUDE }} CT_SKIP_SLOW=1 CYTHON_FORCE_REGEN=${{ matrix.py == '38' && '1' || '0' }}
           CIBW_BUILD: cp${{ matrix.py }}-${{ matrix.libc }}linux*
           CIBW_ARCHS: ${{ matrix.arch }}
           # cibuildwheel on Linux uses a Docker container to run the build, so
@@ -250,7 +250,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels
+          name: cibw-wheels-linux-${{ strategy.job-index }}
 
   windows-wheel:
     name: Build ${{ matrix.arch }} Windows Wheels for py${{ matrix.py }}
@@ -260,9 +260,9 @@ jobs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        py: ["38", "39", "310", "311"]
+        py: ["38", "39", "310", "311", "312"]
         arch: ["AMD64", "x86"]
-      fail-fast: true
+      fail-fast: false
     env:
       BOOST_ROOT: ${{ github.workspace }}/3rdparty/boost
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
@@ -275,7 +275,7 @@ jobs:
         run: tar -xvf *.tar.gz --strip-components=1
         shell: bash
       - name: Restore Boost cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-boost
         with:
           path: ${{env.BOOST_ROOT}}
@@ -293,7 +293,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_ENVIRONMENT: BOOST_INCLUDE=${BOOST_ROOT} CT_SKIP_SLOW=1
+          CIBW_ENVIRONMENT: BOOST_INCLUDE=${BOOST_ROOT} CT_SKIP_SLOW=1 CYTHON_FORCE_REGEN=${{ matrix.py == '38' && '1' || '0' }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: cp${{ matrix.py }}-*
           CIBW_TEST_COMMAND: pytest -vv --durations=100 ${{ runner.temp }}/test/python
@@ -303,7 +303,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels
+          name: cibw-wheels-windows-${{ strategy.job-index }}
 
   macos-wheel:
     name: Build ${{ matrix.arch }} macOS Wheels for py${{ matrix.py }}
@@ -313,7 +313,7 @@ jobs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        py: ["39", "310", "311"]
+        py: ["39", "310", "311", "312"]
         arch: ["x86_64", "arm64"]
         deployment_target: ["11.0"]
         include:
@@ -338,7 +338,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_ENVIRONMENT: BOOST_INCLUDE="$(brew --prefix)/include" RUNNER_TEMP=${{ runner.temp }} CT_SKIP_SLOW=1
+          CIBW_ENVIRONMENT: BOOST_INCLUDE="$(brew --prefix)/include" RUNNER_TEMP=${{ runner.temp }} CT_SKIP_SLOW=1 CYTHON_FORCE_REGEN=${{ matrix.py == '38' && '1' || '0' }}
           CIBW_BUILD: cp${{ matrix.py }}-*
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           # Testing won't be available for macOS ARM until native ARM runners are available.
@@ -350,7 +350,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels
+          name: cibw-wheels-macos-${{ strategy.job-index }}
 
   publish-files-to-pypi:
     name: Publish distribution files to PyPI

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -126,7 +126,9 @@ jobs:
         run: |
           python3 `which scons` sdist f90_interface=n python_package='none' \
           system_blas_lapack=n system_sundials=n system_eigen=n system_fmt=n \
-          system_yamlcpp=n googletest=none
+          system_yamlcpp=n googletest=none env_vars='CYTHON_FORCE_REGEN'
+        env:
+          CYTHON_FORCE_REGEN: "1"
       - name: Archive the built sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -336,6 +336,8 @@ jobs:
           merge-multiple: true
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   send_status_to_cantera:
     name: Send jobs status to Cantera/cantera

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         py: ["38", "39", "310", "311", "312"]
-        arch: ["x86_64"]#, "aarch64"]
+        arch: ["x86_64", "aarch64"]
         libc: ["many"]
       fail-fast: true
     env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -110,12 +110,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libboost-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           repository: "Cantera/cantera"
           submodules: recursive
           ref: ${{ github.event.inputs.incoming_ref }}
+          depth: 1
       - name: Set Up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -341,8 +341,6 @@ jobs:
         env:
           CIBW_ENVIRONMENT: BOOST_INCLUDE="$(brew --prefix)/include" RUNNER_TEMP=${{ runner.temp }} CT_SKIP_SLOW=1 CYTHON_FORCE_REGEN=${{ matrix.py == '38' && '1' || '0' }}
           CIBW_BUILD: cp${{ matrix.py }}-*
-          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
-          # Testing won't be available for macOS ARM until native ARM runners are available.
           CIBW_TEST_COMMAND: pytest -vv --durations=100 ${RUNNER_TEMP}/test/python
           CIBW_BEFORE_TEST: |
             curl -sL "https://github.com/cantera/cantera/archive/${{ needs.post-pending-status.outputs.incoming-sha }}.tar.gz" -o ${{ runner.temp }}/cantera.tar.gz && tar -xzf ${{ runner.temp }}/cantera.tar.gz --strip-components=1 -C ${{ runner.temp }} "cantera-${{ needs.post-pending-status.outputs.incoming-sha }}/test"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -308,24 +308,24 @@ jobs:
           name: cibw-wheels-windows-${{ strategy.job-index }}
 
   macos-wheel:
-    name: Build ${{ matrix.arch }} macOS Wheels for py${{ matrix.py }}
-    runs-on: macos-11
+    name: Build ${{ matrix.macos-version }} Wheels for py${{ matrix.py }}
+    runs-on: ${{ matrix.macos-version }}
     needs: ["sdist", "post-pending-status"]
     outputs:
       job-status: ${{ job.status }}
     strategy:
       matrix:
-        py: ["39", "310", "311", "312"]
-        arch: ["x86_64", "arm64"]
+        macos-version: [ "macos-13", "macos-14" ]
+        py: [ "39", "310", "311", "312" ]
         deployment_target: ["11.0"]
         include:
           - py: "38"
             deployment_target: "10.15"
-            arch: "x86_64"
+            macos-version: "macos-13"
           - py: "38"
             deployment_target: "10.15"
-            arch: "arm64"
-      fail-fast: true
+            macos-oversion: "macos-14"
+      fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
     steps:
@@ -344,7 +344,6 @@ jobs:
           CIBW_BUILD: cp${{ matrix.py }}-*
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           # Testing won't be available for macOS ARM until native ARM runners are available.
-          CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_TEST_COMMAND: pytest -vv --durations=100 ${RUNNER_TEMP}/test/python
           CIBW_BEFORE_TEST: |
             curl -sL "https://github.com/cantera/cantera/archive/${{ needs.post-pending-status.outputs.incoming-sha }}.tar.gz" -o ${{ runner.temp }}/cantera.tar.gz && tar -xzf ${{ runner.temp }}/cantera.tar.gz --strip-components=1 -C ${{ runner.temp }} "cantera-${{ needs.post-pending-status.outputs.incoming-sha }}/test"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -336,8 +336,6 @@ jobs:
           merge-multiple: true
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   send_status_to_cantera:
     name: Send jobs status to Cantera/cantera

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   CIBW_BUILD_FRONTEND: build
-  CIBW_TEST_EXTRAS: pandas,units
+  CIBW_TEST_EXTRAS: pandas,units,graphviz
   CIBW_TEST_REQUIRES: pytest
   ACTION_URL: "https://github.com/Cantera/pypi-packages/actions/runs/${{ github.run_id }}"
 


### PR DESCRIPTION
These changes (along with Cantera/cantera#1713) enable compiling with NumPy 2.0 for the sdist and wheels for Python 3.9 and up, while remaining on `oldest_supported_numpy` for Python 3.8, for which NumPy 2.0 was not released.

Other changes (all the numbers quoted are assuming that none of the null results are counted):
* Don't build wheels for x86/win32 Windows. We have 10 downloads all-time on win32
* Don't build wheels for some of the weird Linux archs (ppc and s390x). Those are emulated archs and are really slow to build. We have ~20 lifetime downloads on ppc and zero on s390x.
* Don't build wheels for musl libc, zero lifetime downloads.
* Don't build wheels for Python 3.8/Darwin/arm64 (Apple Silicon). This is not well supported by Python/cibuildwheel upstream and we have only 83 lifetime downloads for that combination. Users should be able to build from an sdist if needed.

TODO
- [x] Fix retrieving the wheels for upload. [This page](https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/#github-actions) shows how to do that for upload v4
- [x] Set up authorized publisher for PyPI