### PR TITLE
Add BLAS/LAPACK support for macOS and Linux

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -280,7 +280,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_ENVIRONMENT_LINUX: CT_SKIP_SLOW=1 CANTERA_TEST_DIR=/host/${{ steps.download-test-files.outputs.test-root }}
           CIBW_ENVIRONMENT_WINDOWS: CT_SKIP_SLOW=1 CMAKE_BUILD_PARALLEL_LEVEL=4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -157,7 +157,7 @@ jobs:
         # one for each Python version
         os: [ubuntu-latest]
         arch: [aarch64]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: ubuntu-latest
             arch: x86_64

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -166,7 +166,7 @@ jobs:
             boost-arch: x86
             boost-toolset: msvc
             boost-platform-version: 2022
-            boost-version: "1.85.0"
+            boost-version: "1.86.0"
           - os: macos-14
             arch: arm64
             boost-arch: aarch64
@@ -174,7 +174,7 @@ jobs:
             # Since we only use the headers, we can use the platform version for this
             # macos version
             boost-platform-version: "14"
-            boost-version: "1.85.0"
+            boost-version: "1.86.0"
           - os: macos-13
             arch: x86_64
             boost-arch: x86
@@ -182,7 +182,7 @@ jobs:
             # Since we only use the headers, we can use the platform version for this
             # macos version
             boost-platform-version: "13"
-            boost-version: "1.85.0"
+            boost-version: "1.86.0"
       fail-fast: false
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
- **Bump Boost to match Linux base image**
- **Add Python3.13 for aarch64 builds**
- **Bump cibuildwheel**
- **Bump libhdf5 on macOS**

Link with Accelerate on macOS. Make sure that linking BLAS/LAPACK from the base image works for Linux
