### PR TITLE
Fix fetching SHA associated with a tag

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           if [[ "${INCOMING_SHA}" == "" ]]; then
             INCOMING_SHA=$(gh api repos/cantera/cantera/git/matching-refs/${INCOMING_REF} \
-              -H "Accept: application/vnd.github.v3+json" --jq ".[0].object.sha")
+              -H "Accept: application/vnd.github.v3+json" \
+              --jq '.[] | select(.ref == "refs/${INCOMING_REF}") | .object.sha'
             echo "INCOMING_SHA=${INCOMING_SHA}" >> $GITHUB_ENV
           fi
           # This needs to be in this step to be output to other jobs.


### PR DESCRIPTION
The "gh api" command returns all refs matching a tag, including partial matches. Since we need an exact match, we get this through an additional filtering step.