### PR TITLE
Bump cibuildwheel and setup-uv, fix dependabot jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Install boost
         # Our custom manylinux images already have Boost installed
         if: runner.os != 'Linux'
-        uses: MarkusJx/install-boost@v2.5.0
+        uses: MarkusJx/install-boost@b1f0ee8b87cf60236b72440c72d0085d002770c5 #v2.5.0
         id: install-boost
         with:
             # REQUIRED: Specify the required boost version
@@ -279,7 +279,7 @@ jobs:
           key: ${{ steps.restore-built-libraries.outputs.cache-primary-key }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a # v2.23.3
         env:
           CANTERA_TEST_DIR: ${{ steps.download-test-files.outputs.test-root }}
           CIBW_ENVIRONMENT_LINUX: CT_SKIP_SLOW=1 CANTERA_TEST_DIR=/host${{ steps.download-test-files.outputs.test-root }}
@@ -315,7 +315,7 @@ jobs:
           pattern: cibw-*
           merge-multiple: true
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   send_status_to_cantera:
     name: Send jobs status to Cantera/cantera

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,11 @@ jobs:
     name: Post a pending workflow status to Cantera/cantera
     runs-on: ubuntu-24.04
     env:
-      GITHUB_TOKEN: ${{ secrets.CANTERA_REPO_STATUS }}
+      # The second part of this expression is a fallback in case the first part is
+      # not set. Dependabot doesn't have the CANTERA_REPO_STATUS secret set, so it
+      # will use the GITHUB_TOKEN provided by GitHub Actions. This is fine because
+      # the status is not posted upstream for pull requests.
+      GITHUB_TOKEN: ${{ secrets.CANTERA_REPO_STATUS || github.token}}
     outputs:
       incoming-ref: ${{ steps.munge-incoming-ref.outputs.incoming-ref }}
       incoming-sha: ${{ steps.munge-incoming-ref.outputs.incoming-sha }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
 
       - name: Run zizmor 🌈
         run: uvx zizmor --format=sarif . > results.sarif


### PR DESCRIPTION
Supersedes #17 and #18

- **Group dependabot updates for GHA**
- **Set GitHub token for API access for Dependabot**
- **Bump cibuildwheel and setup-uv**
